### PR TITLE
Fixing some Windows issues

### DIFF
--- a/rplugin/python3/chadtree/da.py
+++ b/rplugin/python3/chadtree/da.py
@@ -1,3 +1,4 @@
+import sys
 from asyncio import create_subprocess_exec, get_running_loop
 from asyncio.subprocess import PIPE
 from dataclasses import dataclass
@@ -75,7 +76,7 @@ else:
 
 
 def load_json(path: str) -> Any:
-    with open(path) as fd:
+    with open(path, encoding="utf8") as fd:
         return load(fd)
 
 

--- a/rplugin/python3/chadtree/fs.py
+++ b/rplugin/python3/chadtree/fs.py
@@ -12,10 +12,12 @@ from .consts import file_mode, folder_mode
 
 
 def ancestors(path: str) -> Iterator[str]:
-    if not path or path == sep:
+    if not path:
+        return
+    parent = dirname(path)
+    if path == parent:
         return
     else:
-        parent = dirname(path)
         yield from ancestors(parent)
         yield parent
 


### PR DESCRIPTION
Hi!

I have experienced some hiccups on my Windows machine.

- When loading files my Python 3.8 version would default to the `charmap` codec instead of `utf-8` so I specified the codec used.
- On Windows the root directory name is something like `C:\` while `fs.ancestors` would look for `\` to stop the recursion.
   I changed the code to stop the recursion once `dirname(path)` returns itself, this should work on all platforms.

Cheers