### PR TITLE
fix invalid range when re-opening chad after decreasing size below 0

### DIFF
--- a/rplugin/python3/chadtree/transitions.py
+++ b/rplugin/python3/chadtree/transitions.py
@@ -17,6 +17,7 @@ from typing import (
     Tuple,
     cast,
 )
+from operator import sub
 
 from pynvim import Nvim
 from pynvim.api.buffer import Buffer
@@ -205,6 +206,9 @@ async def c_open(nvim: Nvim, state: State, settings: Settings) -> Stage:
 async def c_resize(
     nvim: Nvim, state: State, settings: Settings, direction: Callable[[int, int], int]
 ) -> Stage:
+    if direction is sub and state.width <= 0:
+        return state
+
     new_state = await forward(
         state, settings=settings, width=direction(state.width, 10)
     )


### PR DESCRIPTION
when the user resize (decrease) the size, currently the state keeps decreasing even after state.width is 0.
this leads to invalid range error when re-opening chadtree.

![flameshot_2020-08-14_09-14-49](https://user-images.githubusercontent.com/10344542/90208755-bcb5d700-de13-11ea-82ef-934c907c4b72.png)

i add a simple check to prevent changing state when the width is already 0.

hope this helps.
