### PR TITLE
Option to give back focus on open

### DIFF
--- a/rplugin/python3/chadtree/__init__.py
+++ b/rplugin/python3/chadtree/__init__.py
@@ -154,13 +154,13 @@ class Main:
                 except NvimError:
                     self.ch.set()
 
-    @command("CHADopen")
-    def fm_open(self, *args: Any, **kwargs: Any) -> None:
+    @command("CHADopen", nargs="*")
+    def fm_open(self, c_args: str, *args: Any, **kwargs: Any) -> None:
         """
         Toggle sidebar
         """
 
-        self._run(c_open)
+        self._run(c_open, args=c_args)
 
     @function("CHADschedule_update")
     def schedule_udpate(self, args: Sequence[Any]) -> None:

--- a/rplugin/python3/chadtree/opts.py
+++ b/rplugin/python3/chadtree/opts.py
@@ -1,0 +1,26 @@
+from argparse import ArgumentParser
+from typing import NoReturn
+
+from .types import OpenArgs, Sequence
+
+
+class ArgparseError(Exception):
+    pass
+
+
+class Argparse(ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        raise ArgparseError(message)
+
+    def exit(self, status: int = 0, message: str = "") -> NoReturn:
+        msg = self.format_help()
+        raise ArgparseError(msg)
+
+
+def parse_args(args: Sequence[str]) -> OpenArgs:
+    parser = Argparse()
+    parser.add_argument("--nofocus", dest="focus", action="store_false")
+
+    ns = parser.parse_args(args=args)
+    opts = OpenArgs(focus=ns.focus)
+    return opts

--- a/rplugin/python3/chadtree/opts.py
+++ b/rplugin/python3/chadtree/opts.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentParser
-from typing import NoReturn
+from typing import NoReturn, Optional
 
 from .types import OpenArgs, Sequence
 
@@ -12,7 +12,7 @@ class Argparse(ArgumentParser):
     def error(self, message: str) -> NoReturn:
         raise ArgparseError(message)
 
-    def exit(self, status: int = 0, message: str = "") -> NoReturn:
+    def exit(self, status: int = 0, message: Optional[str] = None) -> NoReturn:
         msg = self.format_help()
         raise ArgparseError(msg)
 

--- a/rplugin/python3/chadtree/transitions.py
+++ b/rplugin/python3/chadtree/transitions.py
@@ -200,7 +200,7 @@ async def c_open(
 
         def cont() -> str:
             name = find_current_buffer_name(nvim)
-            toggle_fm_window(nvim, state=state, settings=settings)
+            toggle_fm_window(nvim, state=state, settings=settings, opts=opts)
             return name
 
         current = await call(nvim, cont)

--- a/rplugin/python3/chadtree/transitions.py
+++ b/rplugin/python3/chadtree/transitions.py
@@ -37,7 +37,6 @@ from .fs import (
     unify_ancestors,
 )
 from .git import status
-from .logging import log
 from .nvim import call, getcwd, print
 from .opts import ArgparseError, parse_args
 from .quickfix import quickfix
@@ -198,7 +197,6 @@ async def c_open(
         await print(nvim, e, error=True)
         return None
     else:
-        log.warn("%s", opts)
 
         def cont() -> str:
             name = find_current_buffer_name(nvim)

--- a/rplugin/python3/chadtree/transitions.py
+++ b/rplugin/python3/chadtree/transitions.py
@@ -2,7 +2,6 @@ from asyncio import gather
 from itertools import chain
 from locale import strxfrm
 from mimetypes import guess_type
-from operator import sub
 from os import linesep
 from os.path import basename, dirname, exists, isdir, join, relpath, sep
 from typing import (
@@ -38,7 +37,9 @@ from .fs import (
     unify_ancestors,
 )
 from .git import status
+from .logging import log
 from .nvim import call, getcwd, print
+from .opts import ArgparseError, parse_args
 from .quickfix import quickfix
 from .search import search
 from .state import dump_session, forward
@@ -188,19 +189,29 @@ async def c_quit(nvim: Nvim, state: State, settings: Settings) -> None:
     await call(nvim, cont)
 
 
-async def c_open(nvim: Nvim, state: State, settings: Settings) -> Stage:
-    def cont() -> str:
-        name = find_current_buffer_name(nvim)
-        toggle_fm_window(nvim, state=state, settings=settings)
-        return name
-
-    current = await call(nvim, cont)
-
-    stage = await _current(nvim, state=state, settings=settings, current=current)
-    if stage:
-        return stage
+async def c_open(
+    nvim: Nvim, state: State, settings: Settings, args: Sequence[str]
+) -> Optional[Stage]:
+    try:
+        opts = parse_args(args)
+    except ArgparseError as e:
+        await print(nvim, e, error=True)
+        return None
     else:
-        return Stage(state)
+        log.warn("%s", opts)
+
+        def cont() -> str:
+            name = find_current_buffer_name(nvim)
+            toggle_fm_window(nvim, state=state, settings=settings)
+            return name
+
+        current = await call(nvim, cont)
+
+        stage = await _current(nvim, state=state, settings=settings, current=current)
+        if stage:
+            return stage
+        else:
+            return Stage(state)
 
 
 async def c_resize(

--- a/rplugin/python3/chadtree/types.py
+++ b/rplugin/python3/chadtree/types.py
@@ -8,6 +8,11 @@ Index = Set[str]
 Selection = Set[str]
 
 
+@dataclass(frozen=True)
+class OpenArgs:
+    focus: bool
+
+
 class Mode(IntEnum):
     orphan_link = auto()
     link = auto()

--- a/rplugin/python3/chadtree/wm.py
+++ b/rplugin/python3/chadtree/wm.py
@@ -9,7 +9,7 @@ from .consts import fm_filetype, fm_namespace
 from .fs import is_parent
 from .logging import log
 from .nvim import atomic
-from .types import Badge, ClickType, Highlight, Settings, State
+from .types import Badge, ClickType, Highlight, OpenArgs, Settings, State
 
 
 class HoldWindowPosition:
@@ -158,7 +158,10 @@ def ensure_side_window(
         resize_fm_windows(nvim, state.width)
 
 
-def toggle_fm_window(nvim: Nvim, *, state: State, settings: Settings) -> None:
+def toggle_fm_window(
+    nvim: Nvim, *, state: State, settings: Settings, opts: OpenArgs
+) -> None:
+    cwin: Window = nvim.api.get_current_win()
     window: Optional[Window] = next(find_fm_windows_in_tab(nvim), None)
     if window:
         windows: Sequence[Window] = nvim.api.list_wins()
@@ -175,6 +178,8 @@ def toggle_fm_window(nvim: Nvim, *, state: State, settings: Settings) -> None:
         for option in settings.win_local_opts:
             nvim.api.command(f"setlocal {option}")
         ensure_side_window(nvim, window=window, state=state, settings=settings)
+        if opts.focus:
+            nvim.api.set_current_win(cwin)
 
 
 def show_file(

--- a/rplugin/python3/chadtree/wm.py
+++ b/rplugin/python3/chadtree/wm.py
@@ -178,7 +178,7 @@ def toggle_fm_window(
         for option in settings.win_local_opts:
             nvim.api.command(f"setlocal {option}")
         ensure_side_window(nvim, window=window, state=state, settings=settings)
-        if opts.focus:
+        if not opts.focus:
             nvim.api.set_current_win(cwin)
 
 


### PR DESCRIPTION
New configuration `focus_on_open`. By default set to `true` to be consistent with the current behaviour.

Closes #54 