### PR TITLE
Allow to rename when paths exist in copy/ cut operations

### DIFF
--- a/rplugin/python3/chadtree/transitions.py
+++ b/rplugin/python3/chadtree/transitions.py
@@ -693,6 +693,18 @@ async def _operation(
 
         pre_existing = await run_in_executor(p_pre)
         if pre_existing:
+            # If path(s) already exist, allow user to rename the destination
+            for source, dest in pre_existing.items():
+                def ask_rename() -> bool:
+                    resp = nvim.funcs.input("Path exist!!! Rename: ", dest)
+                    return resp
+                new_dest = await call(nvim, ask_rename)
+                operations[source] = new_dest
+
+            pre_existing = await run_in_executor(p_pre)
+
+        if pre_existing:
+            # If path(s) still exist after renaming the dest, show an error message
             msg = ", ".join(
                 f"{_display_path(s, state=state)} -> {_display_path(d, state=state)}"
                 for s, d in sorted(pre_existing.items(), key=lambda t: strxfrm(t[0]))
@@ -702,7 +714,6 @@ async def _operation(
             )
             return None
         else:
-
             msg = linesep.join(
                 f"{_display_path(s, state=state)} -> {_display_path(d, state=state)}"
                 for s, d in sorted(operations.items(), key=lambda t: strxfrm(t[0]))

--- a/rplugin/python3/chadtree/transitions.py
+++ b/rplugin/python3/chadtree/transitions.py
@@ -699,7 +699,10 @@ async def _operation(
                     resp = nvim.funcs.input("Path exist!!! Rename: ", dest)
                     return resp
                 new_dest = await call(nvim, ask_rename)
-                operations[source] = new_dest
+                if new_dest:
+                    operations[source] = new_dest
+                else:
+                    return None
 
             pre_existing = await run_in_executor(p_pre)
 


### PR DESCRIPTION
Hi, 
Thank you for this wonderful project.
I usually face the problem when copy/cut items to a folder that already exists. 
In this pull request, it just allows the user to rename folder/ files if the destination file/folder already exists.