### PR TITLE
Remove Protocol typing import

### DIFF
--- a/rplugin/python3/chadtree/localization.py
+++ b/rplugin/python3/chadtree/localization.py
@@ -1,7 +1,7 @@
 from locale import getdefaultlocale
 from os.path import join
 from string import Template
-from typing import Dict, Optional, Protocol, cast
+from typing import Dict, Optional, cast
 
 from .da import load_json
 from .logging import log


### PR DESCRIPTION
The Protocol type was introduced in PEP544 https://www.python.org/dev/peps/pep-0544/, which is not supported by Python 3.7. Removed the import, which was not used by the file anyway.