### PR TITLE
Use pip of provided Python executable

### DIFF
--- a/chadtree/__main__.py
+++ b/chadtree/__main__.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser, Namespace
 from shutil import which
-from subprocess import DEVNULL, run
-from sys import path, stderr, stdout, version_info
+from subprocess import DEVNULL, CalledProcessError, run
+from sys import executable, path, stderr, stdout, version_info
 from textwrap import dedent
 from typing import Union
 from webbrowser import open as open_w
@@ -37,21 +37,28 @@ args = parse_args()
 command: Union[Literal["deps"], Literal["run"]] = args.command
 
 if command == "deps":
-    cmd = "pip3"
-    if not which(cmd):
-        print("Cannot find pip3! Please install pip3 separately", file=stderr)
+    cmd = [executable, "-m", "pip"]
+    try:
+        run(
+            cmd + ["--version", ],
+            check=True,
+            stdin=DEVNULL,
+            stderr=stdout,
+            cwd=str(RT_DIR),
+        )
+    except CalledProcessError as e:
+        print(f"{e}\nPlease install pip separately.", file=stderr)
         exit(1)
     else:
         proc = run(
-            (
-                cmd,
+            cmd + [
                 "install",
                 "--upgrade",
                 "--target",
                 str(RT_DIR),
                 "--requirement",
                 str(REQUIREMENTS),
-            ),
+            ],
             stdin=DEVNULL,
             stderr=stdout,
             cwd=str(RT_DIR),

--- a/lua/chadtree.lua
+++ b/lua/chadtree.lua
@@ -14,6 +14,7 @@ return function (args)
     local job_id = nil
     local chad_params = {}
     local err_exit = false
+    local py3 = vim.g.python3_host_prog or "python3"
 
     local function defer(timeout, callback)
       local timer = vim.loop.new_timer()
@@ -56,7 +57,7 @@ return function (args)
       local cwd = "/" .. top_lv
       local args =
         vim.tbl_flatten {
-        {"python3", "-m", "chadtree"},
+        {py3, "-m", "chadtree"},
         {...}
       }
       local params = {


### PR DESCRIPTION
`pip3` is not necessarily the `pip` executable of the Python
installation that provides `python3`. Therefore the installation may
result in an error like this:

```
$ /home/christian/.config/nvim/python3/bin/python -m chadtree deps
Looking in indexes: https://pypi.org/simple, https://cdn.crate.io/downloads/pypi
Collecting git+https://github.com/ms-jpq/std2.git@b6e6a9e2d36c719b0099fd8d4b5d669bc8b43816 (from -r /home/christian/sandbox/misc/chadtree/requirements.txt (line 3))
  Cloning https://github.com/ms-jpq/std2.git (to revision b6e6a9e2d36c719b0099fd8d4b5d669bc8b43816) to /tmp/pip-req-build-ohqmlycq
  Running command git clone -q https://github.com/ms-jpq/std2.git /tmp/pip-req-build-ohqmlycq
  Running command git checkout -q b6e6a9e2d36c719b0099fd8d4b5d669bc8b43816
ERROR: Package 'std2' requires a different Python: 3.7.9 not in '>=3.8.0'
WARNING: You are using pip version 20.1.1; however, version 20.3.3 is available.
You should consider upgrading via the '/usr/local/bin/python3.7 -m pip install --upgrade pip' command.
Installation failed, check :message
```

Therefore this commit changes the `deps` command to use the `pip` of the
python executable that executes the `__main__.py` file when running
`python3 -m chadtree deps`.

This is also useful when you have your Neovim Python dependencies
installed in a virtualenv, because then you can change the `do` command
for the plugin installation to use the Python executable path of the
virtualenv:

```
Plug 'ms-jpq/chadtree.vim', { 'do': '/path/to/neovim-virtualenv/bin/python -m chadtree deps' }
```