### PR TITLE
Close on open file functionality

### DIFF
--- a/chadtree/settings/load.py
+++ b/chadtree/settings/load.py
@@ -41,6 +41,7 @@ class _UserOptions:
     session: bool
     show_hidden: bool
     version_control: VersionCtlOpts
+    close_on_open: bool
 
 
 @dataclass(frozen=True)
@@ -140,6 +141,7 @@ def initial(nvim: Nvim, specs: Sequence[RpcSpec]) -> Settings:
         win_local_opts=view.window_options,
         xdg=config.xdg,
         profiling=config.profiling,
+        close_on_open=options.close_on_open
     )
 
     return settings

--- a/chadtree/settings/types.py
+++ b/chadtree/settings/types.py
@@ -35,3 +35,4 @@ class Settings:
     win_actual_opts: Mapping[str, Union[bool, str]]
     win_local_opts: Mapping[str, Union[bool, str]]
     profiling: bool
+    close_on_open: bool

--- a/chadtree/transitions/click.py
+++ b/chadtree/transitions/click.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from pynvim import Nvim
 from pynvim_pp.lib import write
+from pynvim_pp.api import list_wins, win_close
+from .shared.wm import find_fm_windows_in_tab
 
 from ..fs.cartographer import is_dir
 from ..fs.types import Mode
@@ -49,7 +51,15 @@ def _click(
                     path=node.path,
                     click_type=click_type,
                 )
-                return nxt
+
+                if settings.close_on_open:
+                    wins = list_wins(nvim)
+                    if len(wins) <= 1:
+                        nvim.api.command("quit")
+                    else:
+                        for win in find_fm_windows_in_tab(nvim):
+                            win_close(nvim, win=win)
+                    return nxt
 
 
 @rpc(blocking=False)

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -93,6 +93,7 @@ options:
   show_hidden: false
   version_control:
     enable: true
+  close_on_open: false
 theme:
   icon_glyph_set: devicons
   text_colour_set: env


### PR DESCRIPTION
Hello, this adds functionality for making CHADTree close whenever a file is opened via the setting `close_on_open: bool`. Not sure if this is wanted, but its something I threw together for myself. I also see that this would close #115 , but as a setting, not as a new click. 

Let me know if you want to use this, I can write docs and anything else necessary with some guidance on what to do, this is the first time im working on this repo.