### PR TITLE
async git-status now uses `--no-optional-locks`

### DIFF
--- a/chadtree/version_ctl/git.py
+++ b/chadtree/version_ctl/git.py
@@ -24,7 +24,7 @@ from ..registry import pool
 from .types import VCStatus
 
 _WHITE_SPACES = {*whitespace}
-_GIT_LIST_CMD = ("git", "status", "--ignored", "--renames", "--porcelain", "-z")
+_GIT_LIST_CMD = ("git", "--no-optional-locks", "status", "--ignored", "--renames", "--porcelain", "-z")
 _GIT_ENV = {"LC_ALL": "C"}
 
 _GIT_SUBMODULE_MARKER = "Entering "
@@ -35,7 +35,7 @@ _UNTRACKED_MARKER = "?"
 
 def root(cwd: PurePath) -> PurePath:
     stdout = check_output(
-        ("git", "rev-parse", "--show-toplevel"), stderr=PIPE, text=True, cwd=cwd
+        ("git", "--no-optional-locks", "rev-parse", "--show-toplevel"), stderr=PIPE, text=True, cwd=cwd
     )
     return PurePath(stdout.rstrip())
 


### PR DESCRIPTION
## Summary
git-status running in the background can conflict with interactive
commands. In large repositories, git-status can take multiple seconds,
effectively locking users out of using git commands for that period of
time. This commit adds the `no-optional-locks` option to background git
commands.

## Reproducing the old problem
1. Checkout a large repository with lots of files
2. Modify chadtree poll settings to 1
3. Open nvim and then open chadtree
3. Switch between branches very quickly and check for lock error `fatal: Unable to create '/path/my_proj/.git/index.lock': File exists.`
```
for i in $(seq 1 20); 
   do git co branch1 && git co branch2; done
```
## Test
Ran through the steps above and could not reproduce the old problem