### PR TITLE
Update: replace all os.path.normcase with os.path.normpath

### DIFF
--- a/chadtree/transitions/copy_name.py
+++ b/chadtree/transitions/copy_name.py
@@ -1,6 +1,6 @@
 from locale import strxfrm
 from os import linesep
-from os.path import normcase
+from os.path import normpath
 from pathlib import PurePath
 from typing import Callable, Iterator
 
@@ -46,7 +46,7 @@ def _copy_name(nvim: Nvim, state: State, settings: Settings, is_visual: bool) ->
         nvim,
         state=state,
         is_visual=is_visual,
-        proc=lambda p: normcase(p.name),
+        proc=lambda p: normpath(p.name),
     )
 
 
@@ -62,7 +62,7 @@ def _copy_basename(
         nvim,
         state=state,
         is_visual=is_visual,
-        proc=normcase,
+        proc=normpath,
     )
 
 
@@ -78,5 +78,5 @@ def _copy_relname(
         nvim,
         state=state,
         is_visual=is_visual,
-        proc=lambda p: normcase(p.relative_to(state.root.path)),
+        proc=lambda p: normpath(p.relative_to(state.root.path)),
     )

--- a/chadtree/transitions/focus.py
+++ b/chadtree/transitions/focus.py
@@ -1,4 +1,4 @@
-from os.path import normcase
+from os.path import normpath
 from pathlib import PurePath
 from typing import Optional
 
@@ -66,7 +66,7 @@ def _change_dir(
             nvim, state=state, settings=settings, new_cwd=cwd, indices=set()
         )
         chdir(nvim, path=new_state.root.path)
-        write(nvim, LANG("new cwd", cwd=normcase(new_state.root.path)))
+        write(nvim, LANG("new cwd", cwd=normpath(new_state.root.path)))
         return Stage(new_state, focus=new_state.root.path)
 
 

--- a/chadtree/transitions/shared/open_file.py
+++ b/chadtree/transitions/shared/open_file.py
@@ -1,7 +1,7 @@
 from contextlib import nullcontext
 from itertools import chain
 from mimetypes import guess_type
-from os.path import altsep, normcase, sep
+from os.path import altsep, normpath, sep
 from pathlib import PurePath
 from typing import Optional
 
@@ -82,7 +82,7 @@ def _show_file(
             win = cur_win(nvim)
 
             if buf is None:
-                escaped = nvim.funcs.fnameescape(normcase(path))
+                escaped = nvim.funcs.fnameescape(normpath(path))
                 nvim.command(f"edit! {escaped}")
             else:
                 win_set_buf(nvim, win=win, buf=buf)

--- a/chadtree/transitions/shared/wm.py
+++ b/chadtree/transitions/shared/wm.py
@@ -1,5 +1,5 @@
 from math import inf
-from os.path import normcase
+from os.path import normpath
 from pathlib import Path, PurePath
 from typing import AbstractSet, Iterator, Mapping, Optional, Tuple, Union
 
@@ -209,7 +209,7 @@ def kill_buffers(
                 p.touch()
                 with hold_win_pos(nvim):
                     set_cur_win(nvim, win=win)
-                    escaped = nvim.funcs.fnameescape(normcase(new_path))
+                    escaped = nvim.funcs.fnameescape(normpath(new_path))
                     nvim.command(f"edit! {escaped}")
                     p.unlink(missing_ok=True)
             buf_close(nvim, buf=buf)


### PR DESCRIPTION
This will fix filenames being forced into lowercase on Windows. ( Fixes #242 ) 

I have done basic happy path testing on Windows, Mac and Linux and have not found any unintended side effects

From the [python docs](https://docs.python.org/3/library/os.path.html#os.path.normcase):

normcase: `On Windows, convert all characters in the pathname to
lowercase, and also convert forward slashes to backward slashes. On
other operating systems, return the path unchanged.`

normpath: `Normalize a pathname by collapsing redundant separators and
up-level references so that A//B, A/B/, A/./B and A/foo/../B all become
A/B. This string manipulation may change the meaning of a path that
contains symbolic links. On Windows, it converts forward slashes to
backward slashes.`