### PR TITLE
Prevent CHADTree from closing itself during a secondary click

### DIFF
--- a/chadtree/transitions/click.py
+++ b/chadtree/transitions/click.py
@@ -51,7 +51,7 @@ def _click(
                     click_type=click_type,
                 )
 
-                if settings.close_on_open:
+                if settings.close_on_open and click_type != ClickType.secondary:
                     for win, _ in find_fm_windows(nvim):
                         win_close(nvim, win=win)
 


### PR DESCRIPTION
When enabling `close_on_open` CHADTree will indeed close after opening a file. This makes secondary click obsolete as it'll act the same as primary click. This PR prevents close_on_open behaviour when the `ClickType` is `secondary`.