### PR TITLE
skip adding the root node as a child to itself

### DIFF
--- a/chadtree/fs/cartographer.py
+++ b/chadtree/fs/cartographer.py
@@ -141,6 +141,8 @@ async def _new(
             await sleep(0)
         nodes[node.path] = node
         if parent := nodes.get(node.path.parent):
+            if parent == node:
+                continue
             cast(MutableMapping[PurePath, Node], parent.children)[node.path] = node
 
     return nodes[root]


### PR DESCRIPTION
The root node (`/`) points to itself as a parent, so when `chadtree` attempts to display the root folder, this error occurs:

```
maximum recursion depth exceeded
Traceback (most recent call last):
  File "/Users/vasac/.local/share/nvim/lazy/chadtree/.vars/runtime/lib/python3.12/site-packages/pynvim_pp/logging.py", line 31, in suppress_and_log
    yield None
  File "/Users/vasac/.local/share/nvim/lazy/chadtree/chadtree/client.py", line 188, in c2
    await redraw(state, focus=stage.focus)
  File "/Users/vasac/.local/share/nvim/lazy/chadtree/chadtree/transitions/redraw.py", line 76, in redraw
    focus_row = state.derived.path_row_lookup.get(focus) if focus else None
                ^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/vasac/.local/share/nvim/lazy/chadtree/chadtree/state/cache.py", line 13, in derived
    return render(
           ^^^^^^^
  File "/Users/vasac/.local/share/nvim/lazy/chadtree/chadtree/view/render.py", line 315, in render
    _nodes, _lines, _highlights, _badges = zip(*rendered)
                                           ^^^^^^^^^^^^^^
  File "/Users/vasac/.local/share/nvim/lazy/chadtree/chadtree/view/render.py", line 309, in render
    children = tuple(gen_children())
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vasac/.local/share/nvim/lazy/chadtree/chadtree/view/render.py", line 307, in gen_children
    yield from render(child, depth=depth + 1, cleared=clear)
  File "/Users/vasac/.local/share/nvim/lazy/chadtree/chadtree/view/render.py", line 309, in render
    children = tuple(gen_children())
               ^^^^^^^^^^^^^^^^^^^^^
```