### PR TITLE
Use relative paths for nicer `:ls` & `:f` output

### DIFF
--- a/chadtree/transitions/shared/open_file.py
+++ b/chadtree/transitions/shared/open_file.py
@@ -1,7 +1,7 @@
 from contextlib import suppress
 from json import dumps
 from mimetypes import guess_type
-from os.path import getsize, normpath
+from os.path import getsize, normpath, relpath
 from pathlib import Path, PurePath
 from posixpath import sep
 from typing import AsyncContextManager, Optional, cast
@@ -86,7 +86,8 @@ async def _show_file(*, state: State, click_type: ClickType) -> None:
             if buf:
                 await win.set_buf(buf)
             else:
-                escaped = await Nvim.fn.fnameescape(str, normpath(path))
+                cwd = await Nvim.getcwd()
+                escaped = await Nvim.fn.fnameescape(str, relpath(normpath(path), cwd))
                 await Nvim.exec(f"edit! {escaped}")
 
             await resize_fm_windows(last_used=state.window_order, width=state.width)


### PR DESCRIPTION
Convert paths into relative to CWD before opening files, so the paths are shorter and nicer when viewed from vim. This affects listing open buffers with `:ls` and viewing current file path with `:f` / `CTRL-G`.

Without the patch when vim is run from `~/.local/share/nvim/plugged/chadtree` directory:
```
:ls                                                                                                                                                                                                          
  1  h   "~/.local/share/nvim/plugged/chadtree/README.md" line 1
  4 #h   "~/.local/share/nvim/plugged/chadtree/chadtree/transitions/click.py" line 1
  5 %a   "~/.local/share/nvim/plugged/chadtree/chadtree/transitions/shared/open_file.py" line 1
Press ENTER or type command to continue
```

With the patch:
```
:ls                                                                                                                                                                                                          
  1  h   "README.md"                    line 1
  4 #h   "chadtree/transitions/click.py" line 1
  5 %a   "chadtree/transitions/shared/open_file.py" line 1
Press ENTER or type command to continue
```