### PR TITLE
Allow setting custom view width step

### DIFF
--- a/chadtree/settings/load.py
+++ b/chadtree/settings/load.py
@@ -75,6 +75,7 @@ class _UserTheme:
 class _UserView:
     open_direction: _OpenDirection
     width: int
+    width_step: int
     sort_by: Sequence[Sortby]
     time_format: str
     window_options: Mapping[str, Union[bool, str]]
@@ -169,6 +170,7 @@ async def initial(specs: Iterable[RPCallable]) -> Settings:
             version_ctl=options.version_control,
             view=view_opts,
             width=view.width,
+            width_step=view.width_step,
             win_actual_opts=win_actual_opts,
             win_local_opts=view.window_options,
             xdg=config.xdg,

--- a/chadtree/settings/types.py
+++ b/chadtree/settings/types.py
@@ -36,6 +36,7 @@ class Settings:
     version_ctl: VersionCtlOpts
     view: ViewOptions
     width: int
+    width_step: int
     win_actual_opts: Mapping[str, Union[bool, str]]
     win_local_opts: Mapping[str, Union[bool, str]]
     min_diagnostics_severity: int

--- a/chadtree/transitions/resize.py
+++ b/chadtree/transitions/resize.py
@@ -17,8 +17,9 @@ async def _resize(
     if not await is_fm_window(win):
         return None
     else:
+        step = state.settings.width_step
         old_width = await win.get_width()
-        new_width = max(direction(old_width, 10), 1)
+        new_width = max(direction(old_width, step), 1)
         new_state = await forward(state, width=new_width)
         await resize_fm_windows(new_state.window_order, width=new_state.width)
         return Stage(new_state)

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -162,6 +162,7 @@ view:
     - file_name
   time_format: "%Y-%m-%d %H:%M"
   width: 40
+  width_step: 10
   window_options:
     cursorline: true
     foldenable: false

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -302,6 +302,16 @@ How big is CHADTree when initially opened?
 40
 ```
 
+#### `chadtree_settings.view.width_step`
+
+How much is CHADTree resized in a single step?
+
+**default:**
+
+```json
+10
+```
+
 #### `chadtree_settings.view.window_options`
 
 Set of window local options to for CHADTree windows


### PR DESCRIPTION
Expose window width step in settings. Personally, I prefer a step of `1` for fine window width tuning, but of course individual preferences vary.