### PR TITLE
`no_icons` icon set

### DIFF
--- a/artifacts/artifact.json
+++ b/artifacts/artifact.json
@@ -1256,6 +1256,26 @@
         "selected": "*"
       }
     },
+    "no_icons": {
+      "default_icon": "",
+      "ext_exact": {},
+      "folder": {
+        "closed": "",
+        "open": ""
+      },
+      "link": {
+        "broken": "-/->",
+        "normal": "->"
+      },
+      "name_exact": {},
+      "name_glob": {},
+      "status": {
+        "active": ">",
+        "inactive": " ",
+        "not_selected": " ",
+        "selected": "*"
+      }
+    },
     "devicons": {
       "default_icon": "",
       "ext_exact": {

--- a/assets/icon_base.yml
+++ b/assets/icon_base.yml
@@ -23,6 +23,13 @@ ascii_hollow:
     closed: ▷
     open: ▽
 
+no_icons:
+  <<: *ascii
+  default_icon: ""
+  folder:
+    closed: ""
+    open: ""
+
 devicons: &devicons
   link:
     broken: 󰌸

--- a/chad_types.py
+++ b/chad_types.py
@@ -54,6 +54,7 @@ class IconGlyphSet:
     ascii: IconGlyphs
     devicons: IconGlyphs
     emoji: IconGlyphs
+    no_icons: IconGlyphs
 
 
 class IconGlyphSetEnum(Enum):
@@ -61,6 +62,7 @@ class IconGlyphSetEnum(Enum):
     ascii = auto()
     devicons = auto()
     emoji = auto()
+    no_icons = auto()
 
 
 """

--- a/chadtree/settings/load.py
+++ b/chadtree/settings/load.py
@@ -128,6 +128,7 @@ async def initial(specs: Iterable[RPCallable]) -> Settings:
     use_icons = theme.icon_glyph_set not in {
         IconGlyphSetEnum.ascii,
         IconGlyphSetEnum.ascii_hollow,
+        IconGlyphSetEnum.no_icons,
     }
 
     view_opts = ViewOptions(

--- a/chadtree/view/load.py
+++ b/chadtree/view/load.py
@@ -38,6 +38,8 @@ def load_theme(
         icons = artifact.icons.ascii
     elif icon_set is IconGlyphSetEnum.ascii_hollow:
         icons = artifact.icons.ascii_hollow
+    elif icon_set is IconGlyphSetEnum.no_icons:
+        icons = artifact.icons.no_icons
     elif icon_set is IconGlyphSetEnum.devicons:
         icons = artifact.icons.devicons
     elif icon_set is IconGlyphSetEnum.emoji:

--- a/chadtree/view/render.py
+++ b/chadtree/view/render.py
@@ -164,15 +164,18 @@ def _paint(
 
     def gen_icon(node: Node) -> Iterator[str]:
         yield " "
+
+        icon = None
+
         if is_dir(node):
             if node.pointed and not follow_links:
-                yield icons.link.normal
+                icon = icons.link.normal
             elif node.path in index:
-                yield icons.folder.open
+                icon = icons.folder.open
             else:
-                yield icons.folder.closed
+                icon = icons.folder.closed
         else:
-            yield (
+            icon = (
                 (
                     icons.name_exact.get(node.path.name, "")
                     or icons.ext_exact.get(_lax_suffix(node.path), "")
@@ -188,7 +191,10 @@ def _paint(
                 if settings.view.use_icons
                 else icons.default_icon
             )
-        yield " "
+ 
+        if icon:
+            yield icon
+            yield " "
 
     def gen_name(node: Node) -> Iterator[str]:
         yield encode_for_display(node.path.name)

--- a/ci/text_decorations/__init__.py
+++ b/ci/text_decorations/__init__.py
@@ -91,6 +91,7 @@ def load_text_decors() -> Tuple[IconGlyphSet, TextColourSet]:
     icon_set = IconGlyphSet(
         ascii=_process_icons(icon_spec.ascii),
         ascii_hollow=_process_icons(icon_spec.ascii_hollow),
+        no_icons=_process_icons(icon_spec.no_icons),
         devicons=_process_icons(icon_spec.devicons),
         emoji=_process_icons(icon_spec.emoji),
     )

--- a/docs/THEME.md
+++ b/docs/THEME.md
@@ -82,7 +82,7 @@ Imported from [vim-emoji-icon-theme](https://github.com/adelarsq/vim-emoji-icon-
 
 **no_icons:**
 
-No icons.
+Text-only theme with no icons.
 
 **default:**
 

--- a/docs/THEME.md
+++ b/docs/THEME.md
@@ -80,6 +80,9 @@ Imported from [vim-emoji-icon-theme](https://github.com/adelarsq/vim-emoji-icon-
 
 ![ascii_hollow_icons.png](https://github.com/ms-jpq/chadtree/raw/chad/docs/img/icons_ascii_hollow.png)
 
+**no_icons:**
+
+No icons.
 
 **default:**
 


### PR DESCRIPTION
Icon set for those who prefer a text-only terminal.

I took a liberty to not output a trailing space after an icon if no icon is rendered. Together with empty icons this saves two columns on the screen.

Resolves https://github.com/ms-jpq/chadtree/issues/202.