### PR TITLE
fix permission error on symlinks

### DIFF
--- a/chadtree/fs/cartographer.py
+++ b/chadtree/fs/cartographer.py
@@ -98,7 +98,7 @@ def _fs_stat(path: PurePath) -> Tuple[AbstractSet[Mode], Optional[PurePath]]:
             try:
                 pointed = Path(path).resolve(strict=True)
                 link_info = stat(pointed, follow_symlinks=False)
-            except (FileNotFoundError, NotADirectoryError, RuntimeError):
+            except (FileNotFoundError, NotADirectoryError, RuntimeError, PermissionError):
                 return {Mode.orphan_link}, None
             else:
                 mode = {*_fs_modes(link_info)}


### PR DESCRIPTION
opening vim in /etc on rockylinux9 gave me some permission errors due to a symlink to /boot/grub/grub.cfg this removes that error