### PR TITLE
Add an option to sort the file tree by modification time

### DIFF
--- a/chadtree/fs/cartographer.py
+++ b/chadtree/fs/cartographer.py
@@ -4,6 +4,7 @@ from asyncio import sleep
 from concurrent.futures import Executor
 from contextlib import suppress
 from fnmatch import fnmatch
+from datetime import datetime
 from os import DirEntry, scandir, stat, stat_result
 from os.path import normcase
 from pathlib import Path, PurePath
@@ -88,33 +89,35 @@ def _fs_modes(stat: stat_result) -> Iterator[Mode]:
             yield mode
 
 
-def _fs_stat(path: PurePath) -> Tuple[AbstractSet[Mode], Optional[PurePath]]:
+def _fs_stat(path: PurePath) -> Tuple[AbstractSet[Mode], Optional[PurePath], Optional[datetime]]:
     try:
         info = stat(path, follow_symlinks=False)
     except (FileNotFoundError, PermissionError):
-        return {Mode.orphan_link}, None
+        return {Mode.orphan_link}, None, None
     else:
+        mtime = datetime.fromtimestamp(info.st_mtime)
         if S_ISLNK(info.st_mode) or is_junction(info):
             try:
                 pointed = Path(path).resolve(strict=True)
                 link_info = stat(pointed, follow_symlinks=False)
             except (FileNotFoundError, NotADirectoryError, RuntimeError, PermissionError):
-                return {Mode.orphan_link}, None
+                return {Mode.orphan_link}, None, None
             else:
                 mode = {*_fs_modes(link_info)}
-                return mode | {Mode.link}, pointed
+                return mode | {Mode.link}, pointed, mtime
         else:
             mode = {*_fs_modes(info)}
-            return mode, None
+            return mode, None, mtime
 
 
 def _fs_node(path: PurePath) -> Node:
-    mode, pointed = _fs_stat(path)
+    mode, pointed, mtime = _fs_stat(path)
     node = Node(
         path=path,
         mode=mode,
         pointed=pointed,
         children={},
+        mtime=mtime,
     )
     return node
 
@@ -174,6 +177,7 @@ async def _update(
             mode=root.mode,
             pointed=root.pointed,
             children=children,
+            mtime=root.mtime,
         )
 
 

--- a/chadtree/fs/types.py
+++ b/chadtree/fs/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import IntEnum, auto, unique
 from pathlib import PurePath
 from typing import AbstractSet, Any, Mapping, Optional, Sequence
@@ -42,6 +43,7 @@ class Node:
     path: PurePath
     pointed: Optional[PurePath]
     children: Mapping[PurePath, Node]
+    mtime: Optional[datetime] = None  # Modification time
     cache: _RenderCache = field(default_factory=_RenderCache)
 
 

--- a/chadtree/view/render.py
+++ b/chadtree/view/render.py
@@ -1,4 +1,5 @@
 from collections import UserString
+from datetime import datetime
 from enum import IntEnum, auto
 from fnmatch import fnmatch
 from functools import lru_cache
@@ -81,6 +82,12 @@ def _gen_comp(sortby: Sequence[Sortby]) -> Callable[[Node], Any]:
                         yield strxfrm(node.path.name.casefold())
                     elif sb is Sortby.file_name:
                         yield strxfrm(node.path.name)
+                    elif sb is Sortby.mtime:
+                        # For newest first, we use negative timestamp
+                        yield -(node.mtime.timestamp() if node.mtime else 0)
+                    elif sb is Sortby.mtime_reverse:
+                        # For oldest first, use positive timestamp
+                        yield node.mtime.timestamp() if node.mtime else 0
                     else:
                         never(sb)
 

--- a/chadtree/view/types.py
+++ b/chadtree/view/types.py
@@ -39,6 +39,8 @@ class Sortby(Enum):
     ext = auto()
     file_name_lower = auto()
     file_name = auto()
+    mtime = auto()          # Modification time (newest first)
+    mtime_reverse = auto()  # Modification time (oldest first)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
add option mtime, mtime_reverse.
e.g.  let g:chadtree_settings = { 'view.sort_by' : ["is_folder", "mtime", "file_name_lower", "file_name", "ext"] }